### PR TITLE
Make the NACLSigningPublicKey return the length of a signature

### DIFF
--- a/SodiumObjc/NACLSigningPublicKey.h
+++ b/SodiumObjc/NACLSigningPublicKey.h
@@ -16,4 +16,6 @@
 - (NSData *)verifiedDataFromSignedData:(NSData *)data;
 - (NSData *)verifiedDataFromSignedData:(NSData *)data error:(NSError **)outError;
 
++ (NSUInteger)signatureLength;
+
 @end

--- a/SodiumObjc/NACLSigningPublicKey.m
+++ b/SodiumObjc/NACLSigningPublicKey.m
@@ -52,4 +52,9 @@
     return [data verifiedDataUsingPublicKey:self error:outError];
 }
 
++ (NSUInteger)signatureLength
+{
+    return crypto_sign_BYTES;
+}
+
 @end


### PR DESCRIPTION
It can be useful to have the length of a signature. This method allows that.
