### PR TITLE
Fixing a couple of compiler warnings

### DIFF
--- a/SodiumObjc.xcodeproj/xcshareddata/xcschemes/SodiumObjc-Covered.xcscheme
+++ b/SodiumObjc.xcodeproj/xcshareddata/xcschemes/SodiumObjc-Covered.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0510"
+   LastUpgradeVersion = "0630"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -68,6 +68,15 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A7BF29C91947630800BB35C5"
+            BuildableName = "libSodiumObjc.a"
+            BlueprintName = "SodiumObjc"
+            ReferencedContainer = "container:SodiumObjc.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/SodiumObjc.xcodeproj/xcshareddata/xcschemes/SodiumObjc.xcscheme
+++ b/SodiumObjc.xcodeproj/xcshareddata/xcschemes/SodiumObjc.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0600"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SodiumObjc/NACLAsymmetricKeyPair.m
+++ b/SodiumObjc/NACLAsymmetricKeyPair.m
@@ -12,6 +12,8 @@
 #import <SodiumObjc/NACLKeyPairSubclass.h>
 
 @implementation NACLAsymmetricKeyPair
+@dynamic publicKey;
+@dynamic privateKey;
 
 + (void)initialize 
 {

--- a/SodiumObjc/NACLSigningKeyPair.m
+++ b/SodiumObjc/NACLSigningKeyPair.m
@@ -12,6 +12,8 @@
 #import <SodiumObjc/NACLSigningKeyPair.h>
 
 @implementation NACLSigningKeyPair
+@dynamic publicKey;
+@dynamic privateKey;
 
 + (void)initialize 
 {


### PR DESCRIPTION
Fixing a couple of compiler warnings after updating to compile with the iOS 8.3 SDK.
